### PR TITLE
Add Github link for library

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Vous avez le choix entre :
 
 Il faut ensuite [installer les dépendances](https://www.arduino.cc/en/Guide/Libraries) à notre programme, à savoir les bibliothèques  `Bounce2` et `LiquidCrystal_I2C`. Ces bibliothèques sont normalement disponibles depuis l'interface de l'IDE arduino.
 
+Si vous rencontrez des problèmes avec la bibliothèque `LiquidCrystal_I2C`, il est préférable d'importer directement celle-ci depuis son [repository Github](https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library). 
+
 Une fois l'environnement arduino installé, vous pouvez brancher l'arduino en USB à votre ordinateur.
 
 Le programme à installer sur l'arduino tient en 1 seul fichier `kegwasher.ino`. 


### PR DESCRIPTION
FRENCH bellow

Add link for the LiquidCrystal_I2C library, because she not availaible/or difficult to find it in the Ardunio interface.

French 

Ajout du lien de la bibliothèque LiquidCrystal_I2C, car elle n'est pas disponibles/ ou difficile à trouver dans l'interface Ardunio.